### PR TITLE
Add basic PHP blogging engine with authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Terse
+
 Minimal blogging, maximum clarity.
+
+## Usage
+
+This repository contains a simple blogging engine written in PHP with SQLite storage.
+
+1. Run the built-in PHP server:
+   ```sh
+   php -S localhost:8000
+   ```
+2. Visit `http://localhost:8000/index.php` in your browser.
+3. Log in with the default credentials:
+   - **Username:** `admin`
+   - **Password:** `password`
+4. Create new posts from the "New Post" link.
+
+The database file `blog.db` will be created automatically in the project root.

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+session_start();
+
+function is_logged_in() {
+    return isset($_SESSION['user_id']);
+}
+
+function require_login() {
+    if (!is_logged_in()) {
+        header('Location: login.php');
+        exit();
+    }
+}
+
+function login($username, $password) {
+    $db = get_db();
+    $stmt = $db->prepare("SELECT id, password FROM users WHERE username = ?");
+    $stmt->execute([$username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['username'] = $username;
+        return true;
+    }
+    return false;
+}
+
+function logout() {
+    session_unset();
+    session_destroy();
+}
+?>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,20 @@
+<?php
+function get_db() {
+    static $db = null;
+    if ($db === null) {
+        $db = new PDO('sqlite:' . __DIR__ . '/blog.db');
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $db->exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)");
+        $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
+        $stmt = $db->query("SELECT COUNT(*) as count FROM users");
+        $count = $stmt->fetch(PDO::FETCH_ASSOC)['count'];
+        if ($count == 0) {
+            $username = 'admin';
+            $password = password_hash('password', PASSWORD_DEFAULT);
+            $insert = $db->prepare("INSERT INTO users (username, password) VALUES (?, ?)");
+            $insert->execute([$username, $password]);
+        }
+    }
+    return $db;
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/auth.php';
+$db = get_db();
+
+$posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Blog</title>
+</head>
+<body>
+<h1>Blog</h1>
+<?php if (is_logged_in()): ?>
+<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_post.php">New Post</a> | <a href="logout.php">Logout</a></p>
+<?php else: ?>
+<p><a href="login.php">Login</a></p>
+<?php endif; ?>
+<?php foreach ($posts as $post): ?>
+<article>
+<h2><?php echo htmlspecialchars($post['title']); ?></h2>
+<p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
+<small><?php echo htmlspecialchars($post['created_at']); ?></small>
+</article>
+<hr>
+<?php endforeach; ?>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/auth.php';
+
+if (is_logged_in()) {
+    header('Location: index.php');
+    exit();
+}
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    if (login($username, $password)) {
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Invalid username or password';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+<label for="username">Username</label><br>
+<input type="text" name="username" id="username"><br>
+<label for="password">Password</label><br>
+<input type="password" name="password" id="password"><br>
+<button type="submit">Login</button>
+</form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__ . '/auth.php';
+logout();
+header('Location: login.php');
+exit();
+?>

--- a/new_post.php
+++ b/new_post.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$title = '';
+$content = '';
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $content = trim($_POST['content'] ?? '');
+    if ($title && $content) {
+        $db = get_db();
+        $stmt = $db->prepare("INSERT INTO posts (title, content) VALUES (?, ?)");
+        $stmt->execute([$title, $content]);
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Title and content are required';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>New Post</title>
+</head>
+<body>
+<h1>New Post</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+<label for="title">Title</label><br>
+<input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
+<label for="content">Content</label><br>
+<textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<button type="submit">Publish</button>
+</form>
+<p><a href="index.php">Back to posts</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement SQLite database bootstrap with default admin user
- add session-based authentication and post creation
- provide minimal mobile-friendly blogging pages and usage docs

## Testing
- `php -l db.php auth.php login.php logout.php index.php new_post.php`


------
https://chatgpt.com/codex/tasks/task_e_68a922a3d1348326a3935985da6cf718