### PR TITLE
Allow editing blog title and posts

### DIFF
--- a/db.php
+++ b/db.php
@@ -6,6 +6,13 @@ function get_db() {
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $db->exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)");
         $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
+        $db->exec("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+        $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'blog_title'");
+        $stmt->execute();
+        if ($stmt->fetch(PDO::FETCH_ASSOC)['count'] == 0) {
+            $insert = $db->prepare("INSERT INTO settings (key, value) VALUES ('blog_title', 'Blog')");
+            $insert->execute();
+        }
         $stmt = $db->query("SELECT COUNT(*) as count FROM users");
         $count = $stmt->fetch(PDO::FETCH_ASSOC)['count'];
         if ($count == 0) {
@@ -16,5 +23,19 @@ function get_db() {
         }
     }
     return $db;
+}
+
+function get_blog_title() {
+    $db = get_db();
+    $stmt = $db->prepare("SELECT value FROM settings WHERE key = 'blog_title'");
+    $stmt->execute();
+    $title = $stmt->fetchColumn();
+    return $title !== false ? $title : 'Blog';
+}
+
+function set_blog_title($title) {
+    $db = get_db();
+    $stmt = $db->prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('blog_title', ?)");
+    $stmt->execute([$title]);
 }
 ?>

--- a/edit_post.php
+++ b/edit_post.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$db = get_db();
+$id = intval($_GET['id'] ?? 0);
+$stmt = $db->prepare("SELECT title, content FROM posts WHERE id = ?");
+$stmt->execute([$id]);
+$post = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$post) {
+    header('Location: index.php');
+    exit();
+}
+
+$title = $post['title'];
+$content = $post['content'];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $content = trim($_POST['content'] ?? '');
+    if ($title && $content) {
+        $update = $db->prepare("UPDATE posts SET title = ?, content = ? WHERE id = ?");
+        $update->execute([$title, $content, $id]);
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Title and content are required';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edit Post</title>
+</head>
+<body>
+<h1>Edit Post</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+<label for="title">Title</label><br>
+<input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
+<label for="content">Content</label><br>
+<textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<button type="submit">Update</button>
+</form>
+<p><a href="index.php">Back to posts</a></p>
+</body>
+</html>

--- a/edit_title.php
+++ b/edit_title.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$title = get_blog_title();
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    if ($title) {
+        set_blog_title($title);
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Title is required';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edit Title</title>
+</head>
+<body>
+<h1>Edit Title</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+<label for="title">Title</label><br>
+<input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
+<button type="submit">Save</button>
+</form>
+<p><a href="index.php">Back to posts</a></p>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/auth.php';
 $db = get_db();
+$blog_title = get_blog_title();
 
 $posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -9,12 +10,12 @@ $posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY c
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Blog</title>
+<title><?php echo htmlspecialchars($blog_title); ?></title>
 </head>
 <body>
-<h1>Blog</h1>
+<h1><?php echo htmlspecialchars($blog_title); ?></h1>
 <?php if (is_logged_in()): ?>
-<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_post.php">New Post</a> | <a href="logout.php">Logout</a></p>
+<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="logout.php">Logout</a></p>
 <?php else: ?>
 <p><a href="login.php">Login</a></p>
 <?php endif; ?>
@@ -22,7 +23,7 @@ $posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY c
 <article>
 <h2><?php echo htmlspecialchars($post['title']); ?></h2>
 <p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
-<small><?php echo htmlspecialchars($post['created_at']); ?></small>
+<small><?php echo htmlspecialchars($post['created_at']); ?><?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a><?php endif; ?></small>
 </article>
 <hr>
 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Add settings table and helper methods to store a customizable blog title
- Let logged-in users edit the blog title and update existing posts

## Testing
- `php -l db.php`
- `php -l index.php`
- `php -l edit_post.php`
- `php -l edit_title.php`
- `for f in *.php; do php -l "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68a924c11fd08326828c8a4c7885f1f0