### PR TITLE
Add collection-based post organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ This repository contains a simple blogging engine written in PHP with SQLite sto
 4. Create new posts from the "New Post" link.
 
 The database file `blog.db` will be created automatically in the project root.
+
+## Collections
+
+Posts can now be organized into named collections. When creating or editing a post,
+specify a **Collection** and **Slug**. Each collection has its own listing page, and
+individual posts are rendered using a template matching the collection name from the
+`templates/` directory (falling back to `templates/default.php`). Example URLs:
+
+- `collection.php?name=personal_blog`
+- `post.php?collection=recipes&slug=chicken_soup`
+
+Adding a file like `templates/personal_blog.php` allows subtle style differences for
+that collection.

--- a/collection.php
+++ b/collection.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/auth.php';
+$db = get_db();
+$name = $_GET['name'] ?? '';
+$stmt = $db->prepare("SELECT title, slug, created_at FROM posts WHERE collection = ? ORDER BY created_at DESC");
+$stmt->execute([$name]);
+$posts = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$blog_title = get_blog_title() . ' - ' . $name;
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo htmlspecialchars($blog_title); ?></title>
+</head>
+<body>
+<h1><?php echo htmlspecialchars($name); ?></h1>
+<?php foreach ($posts as $post): ?>
+<article>
+<h2><a href="post.php?collection=<?php echo urlencode($name); ?>&slug=<?php echo urlencode($post['slug']); ?>"><?php echo htmlspecialchars($post['title']); ?></a></h2>
+<small><?php echo htmlspecialchars($post['created_at']); ?></small>
+</article>
+<?php endforeach; ?>
+<p><a href="index.php">Back to posts</a></p>
+</body>
+</html>

--- a/db.php
+++ b/db.php
@@ -5,7 +5,22 @@ function get_db() {
         $db = new PDO('sqlite:' . __DIR__ . '/blog.db');
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $db->exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)");
-        $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
+        $db->exec("CREATE TABLE IF NOT EXISTS posts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            collection TEXT NOT NULL DEFAULT 'general',
+            slug TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )");
+        // Ensure collection and slug columns exist for older databases
+        $columns = $db->query("PRAGMA table_info(posts)")->fetchAll(PDO::FETCH_COLUMN, 1);
+        if (!in_array('collection', $columns)) {
+            $db->exec("ALTER TABLE posts ADD COLUMN collection TEXT NOT NULL DEFAULT 'general'");
+        }
+        if (!in_array('slug', $columns)) {
+            $db->exec("ALTER TABLE posts ADD COLUMN slug TEXT NOT NULL DEFAULT ''");
+        }
         $db->exec("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
         $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'blog_title'");
         $stmt->execute();

--- a/edit_post.php
+++ b/edit_post.php
@@ -4,7 +4,7 @@ require_login();
 
 $db = get_db();
 $id = intval($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT title, content FROM posts WHERE id = ?");
+$stmt = $db->prepare("SELECT title, content, collection, slug FROM posts WHERE id = ?");
 $stmt->execute([$id]);
 $post = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$post) {
@@ -14,18 +14,26 @@ if (!$post) {
 
 $title = $post['title'];
 $content = $post['content'];
+$collection = $post['collection'];
+$slug = $post['slug'];
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $content = trim($_POST['content'] ?? '');
-    if ($title && $content) {
-        $update = $db->prepare("UPDATE posts SET title = ?, content = ? WHERE id = ?");
-        $update->execute([$title, $content, $id]);
+    $collection = trim($_POST['collection'] ?? '');
+    $slug = trim($_POST['slug'] ?? '');
+    if (!$slug) {
+        $slug = strtolower(preg_replace('/[^a-z0-9]+/', '-', $title));
+        $slug = trim($slug, '-');
+    }
+    if ($title && $content && $collection && $slug) {
+        $update = $db->prepare("UPDATE posts SET title = ?, content = ?, collection = ?, slug = ? WHERE id = ?");
+        $update->execute([$title, $content, $collection, $slug, $id]);
         header('Location: index.php');
         exit();
     } else {
-        $message = 'Title and content are required';
+        $message = 'Title, content, collection, and slug are required';
     }
 }
 ?>
@@ -46,6 +54,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
 <label for="content">Content</label><br>
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<label for="collection">Collection</label><br>
+<input type="text" name="collection" id="collection" value="<?php echo htmlspecialchars($collection); ?>"><br>
+<label for="slug">Slug</label><br>
+<input type="text" name="slug" id="slug" value="<?php echo htmlspecialchars($slug); ?>"><br>
 <button type="submit">Update</button>
 </form>
 <p><a href="index.php">Back to posts</a></p>

--- a/index.php
+++ b/index.php
@@ -3,7 +3,8 @@ require_once __DIR__ . '/auth.php';
 $db = get_db();
 $blog_title = get_blog_title();
 
-$posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+$posts = $db->query("SELECT id, title, content, created_at, collection, slug FROM posts ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+$collections = $db->query("SELECT DISTINCT collection FROM posts ORDER BY collection")->fetchAll(PDO::FETCH_COLUMN);
 ?>
 <!DOCTYPE html>
 <html>
@@ -14,6 +15,13 @@ $posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY c
 </head>
 <body>
 <h1><?php echo htmlspecialchars($blog_title); ?></h1>
+<?php if ($collections): ?>
+<nav>
+<?php foreach ($collections as $c): ?>
+<a href="collection.php?name=<?php echo urlencode($c); ?>"><?php echo htmlspecialchars($c); ?></a>
+<?php endforeach; ?>
+</nav>
+<?php endif; ?>
 <?php if (is_logged_in()): ?>
 <p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="logout.php">Logout</a></p>
 <?php else: ?>
@@ -21,9 +29,9 @@ $posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY c
 <?php endif; ?>
 <?php foreach ($posts as $post): ?>
 <article>
-<h2><?php echo htmlspecialchars($post['title']); ?></h2>
+<h2><a href="post.php?collection=<?php echo urlencode($post['collection']); ?>&slug=<?php echo urlencode($post['slug']); ?>"><?php echo htmlspecialchars($post['title']); ?></a></h2>
 <p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
-<small><?php echo htmlspecialchars($post['created_at']); ?><?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a><?php endif; ?></small>
+<small><?php echo htmlspecialchars($post['created_at']); ?> in <?php echo htmlspecialchars($post['collection']); ?><?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a><?php endif; ?></small>
 </article>
 <hr>
 <?php endforeach; ?>

--- a/new_post.php
+++ b/new_post.php
@@ -4,19 +4,27 @@ require_login();
 
 $title = '';
 $content = '';
+$collection = 'general';
+$slug = '';
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $content = trim($_POST['content'] ?? '');
-    if ($title && $content) {
+    $collection = trim($_POST['collection'] ?? 'general');
+    $slug = trim($_POST['slug'] ?? '');
+    if (!$slug) {
+        $slug = strtolower(preg_replace('/[^a-z0-9]+/', '-', $title));
+        $slug = trim($slug, '-');
+    }
+    if ($title && $content && $collection && $slug) {
         $db = get_db();
-        $stmt = $db->prepare("INSERT INTO posts (title, content) VALUES (?, ?)");
-        $stmt->execute([$title, $content]);
+        $stmt = $db->prepare("INSERT INTO posts (title, content, collection, slug) VALUES (?, ?, ?, ?)");
+        $stmt->execute([$title, $content, $collection, $slug]);
         header('Location: index.php');
         exit();
     } else {
-        $message = 'Title and content are required';
+        $message = 'Title, content, collection, and slug are required';
     }
 }
 ?>
@@ -37,6 +45,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
 <label for="content">Content</label><br>
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<label for="collection">Collection</label><br>
+<input type="text" name="collection" id="collection" value="<?php echo htmlspecialchars($collection); ?>"><br>
+<label for="slug">Slug</label><br>
+<input type="text" name="slug" id="slug" value="<?php echo htmlspecialchars($slug); ?>"><br>
 <button type="submit">Publish</button>
 </form>
 <p><a href="index.php">Back to posts</a></p>

--- a/post.php
+++ b/post.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/auth.php';
+$db = get_db();
+$collection = $_GET['collection'] ?? '';
+$slug = $_GET['slug'] ?? '';
+$stmt = $db->prepare("SELECT title, content, created_at, collection FROM posts WHERE collection = ? AND slug = ?");
+$stmt->execute([$collection, $slug]);
+$post = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$post) {
+    http_response_code(404);
+    echo 'Post not found';
+    exit();
+}
+$template = __DIR__ . '/templates/' . $collection . '.php';
+if (!file_exists($template)) {
+    $template = __DIR__ . '/templates/default.php';
+}
+include $template;
+?>

--- a/templates/default.php
+++ b/templates/default.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo htmlspecialchars($post['title']); ?></title>
+</head>
+<body>
+<h1><?php echo htmlspecialchars($post['title']); ?></h1>
+<p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
+<small><?php echo htmlspecialchars($post['created_at']); ?></small>
+<p><a href="collection.php?name=<?php echo urlencode($post['collection']); ?>">Back to <?php echo htmlspecialchars($post['collection']); ?></a></p>
+</body>
+</html>

--- a/templates/personal_blog.php
+++ b/templates/personal_blog.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo htmlspecialchars($post['title']); ?></title>
+<style>
+body { font-family: sans-serif; background-color: #f0f8ff; }
+</style>
+</head>
+<body>
+<h1><?php echo htmlspecialchars($post['title']); ?></h1>
+<p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
+<small><?php echo htmlspecialchars($post['created_at']); ?> in <?php echo htmlspecialchars($post['collection']); ?></small>
+<p><a href="collection.php?name=<?php echo urlencode($post['collection']); ?>">Back to <?php echo htmlspecialchars($post['collection']); ?></a></p>
+</body>
+</html>

--- a/templates/recipes.php
+++ b/templates/recipes.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo htmlspecialchars($post['title']); ?></title>
+<style>
+body { font-family: serif; background-color: #fffbe6; }
+</style>
+</head>
+<body>
+<h1><?php echo htmlspecialchars($post['title']); ?></h1>
+<p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
+<small><?php echo htmlspecialchars($post['created_at']); ?> in <?php echo htmlspecialchars($post['collection']); ?></small>
+<p><a href="collection.php?name=<?php echo urlencode($post['collection']); ?>">Back to <?php echo htmlspecialchars($post['collection']); ?></a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Organize posts into named collections with slug identifiers
- Render each collection with its own template and listing page
- Extend post creation and editing forms to manage collection and slug

## Testing
- `php -l db.php edit_post.php index.php new_post.php collection.php post.php templates/default.php templates/personal_blog.php templates/recipes.php`

------
https://chatgpt.com/codex/tasks/task_e_68a92758829883269db816b964f18a8e