### PR TITLE
Add ability to delete posts

### DIFF
--- a/delete_post.php
+++ b/delete_post.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$id = intval($_GET['id'] ?? 0);
+if ($id) {
+    $db = get_db();
+    $stmt = $db->prepare("DELETE FROM posts WHERE id = ?");
+    $stmt->execute([$id]);
+}
+
+header('Location: index.php');
+exit();
+?>

--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@ $posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY c
 <article>
 <h2><?php echo htmlspecialchars($post['title']); ?></h2>
 <p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
-<small><?php echo htmlspecialchars($post['created_at']); ?><?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a><?php endif; ?></small>
+<small><?php echo htmlspecialchars($post['created_at']); ?><?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a> | <a href="delete_post.php?id=<?php echo $post['id']; ?>" onclick="return confirm('Delete this post?');">Delete</a><?php endif; ?></small>
 </article>
 <hr>
 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- allow removing posts via new delete_post endpoint
- show delete link on index for logged in users

## Testing
- `php -l index.php`
- `php -l delete_post.php`


------
https://chatgpt.com/codex/tasks/task_e_68a92fad69ec83268f1a0980c0ce3cfb