### PR TITLE
Add ability to change username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains a simple blogging engine written in PHP with SQLite sto
 3. Log in with the default credentials:
    - **Username:** `admin`
    - **Password:** `password`
-4. Create new posts from the "New Post" link.
+4. Change the default username and password from the "Edit Account" link.
+5. Create new posts from the "New Post" link.
 
 The database file `blog.db` will be created automatically in the project root.

--- a/edit_user.php
+++ b/edit_user.php
@@ -1,0 +1,86 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$db = get_db();
+$current_username = $_SESSION['username'];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $new_username = trim($_POST['username'] ?? '');
+    $current_password = $_POST['current_password'] ?? '';
+    $new_password = $_POST['new_password'] ?? '';
+    $confirm_password = $_POST['confirm_password'] ?? '';
+
+    if ($new_username === '') {
+        $message = 'Username is required';
+    } elseif ($current_password === '') {
+        $message = 'Current password is required';
+    } else {
+        $stmt = $db->prepare("SELECT password FROM users WHERE id = ?");
+        $stmt->execute([$_SESSION['user_id']]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$user || !password_verify($current_password, $user['password'])) {
+            $message = 'Current password is incorrect';
+        } elseif ($new_password !== '' && $new_password !== $confirm_password) {
+            $message = 'New passwords do not match';
+        } else {
+            $updates = [];
+            $params = [];
+            if ($new_username !== $current_username) {
+                $check = $db->prepare("SELECT COUNT(*) FROM users WHERE username = ? AND id != ?");
+                $check->execute([$new_username, $_SESSION['user_id']]);
+                if ($check->fetchColumn() > 0) {
+                    $message = 'Username already taken';
+                } else {
+                    $updates[] = 'username = ?';
+                    $params[] = $new_username;
+                }
+            }
+            if ($new_password !== '') {
+                $updates[] = 'password = ?';
+                $params[] = password_hash($new_password, PASSWORD_DEFAULT);
+            }
+            if (!$message) {
+                if (count($updates) > 0) {
+                    $params[] = $_SESSION['user_id'];
+                    $sql = 'UPDATE users SET ' . implode(', ', $updates) . ' WHERE id = ?';
+                    $stmt = $db->prepare($sql);
+                    $stmt->execute($params);
+                    $_SESSION['username'] = $new_username;
+                    header('Location: index.php');
+                    exit();
+                } else {
+                    $message = 'No changes made';
+                }
+            }
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edit Account</title>
+</head>
+<body>
+<h1>Edit Account</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+<label for="username">Username</label><br>
+<input type="text" name="username" id="username" value="<?php echo htmlspecialchars($current_username); ?>"><br>
+<label for="current_password">Current Password</label><br>
+<input type="password" name="current_password" id="current_password"><br>
+<label for="new_password">New Password</label><br>
+<input type="password" name="new_password" id="new_password"><br>
+<label for="confirm_password">Confirm New Password</label><br>
+<input type="password" name="confirm_password" id="confirm_password"><br>
+<button type="submit">Save</button>
+</form>
+<p><a href="index.php">Back to posts</a></p>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ $posts = $db->query("SELECT id, title, content, created_at FROM posts ORDER BY c
 <body>
 <h1><?php echo htmlspecialchars($blog_title); ?></h1>
 <?php if (is_logged_in()): ?>
-<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="logout.php">Logout</a></p>
+<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="edit_user.php">Edit Account</a> | <a href="logout.php">Logout</a></p>
 <?php else: ?>
 <p><a href="login.php">Login</a></p>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Add `Edit Account` page to update username and password after verifying the current password
- Link account editing page from the main index navigation
- Document how to change default credentials in the README

## Testing
- `php -l index.php edit_user.php`


------
https://chatgpt.com/codex/tasks/task_e_68a977bf99108326b5c2ae0fb41c2de8