### PR TITLE
Add hierarchical sections with CRUD and section-aware posts

### DIFF
--- a/db.php
+++ b/db.php
@@ -5,8 +5,15 @@ function get_db() {
         $db = new PDO('sqlite:' . __DIR__ . '/blog.db');
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $db->exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, password TEXT NOT NULL)");
-        $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
+        $db->exec("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, section_id INTEGER)");
+        $db->exec("CREATE TABLE IF NOT EXISTS sections (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, parent_id INTEGER REFERENCES sections(id))");
         $db->exec("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+
+        // Ensure the section_id column exists for older installations
+        $columns = $db->query("PRAGMA table_info(posts)")->fetchAll(PDO::FETCH_COLUMN, 1);
+        if (!in_array('section_id', $columns)) {
+            $db->exec("ALTER TABLE posts ADD COLUMN section_id INTEGER");
+        }
         $stmt = $db->prepare("SELECT COUNT(*) AS count FROM settings WHERE key = 'blog_title'");
         $stmt->execute();
         if ($stmt->fetch(PDO::FETCH_ASSOC)['count'] == 0) {

--- a/delete_post.php
+++ b/delete_post.php
@@ -3,12 +3,20 @@ require_once __DIR__ . '/auth.php';
 require_login();
 
 $id = intval($_GET['id'] ?? 0);
+$section_id = 0;
 if ($id) {
     $db = get_db();
+    $stmt = $db->prepare("SELECT section_id FROM posts WHERE id = ?");
+    $stmt->execute([$id]);
+    $section_id = (int)$stmt->fetchColumn();
     $stmt = $db->prepare("DELETE FROM posts WHERE id = ?");
     $stmt->execute([$id]);
 }
 
-header('Location: index.php');
+if ($section_id) {
+    header('Location: view_section.php?id=' . $section_id);
+} else {
+    header('Location: index.php');
+}
 exit();
 ?>

--- a/delete_section.php
+++ b/delete_section.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$id = intval($_GET['id'] ?? 0);
+if ($id) {
+    $db = get_db();
+
+    $stmt = $db->prepare("SELECT parent_id FROM sections WHERE id = ?");
+    $stmt->execute([$id]);
+    $parent_id = (int)$stmt->fetchColumn();
+
+    $delete_section = function($db, $id) use (&$delete_section) {
+        $childStmt = $db->prepare("SELECT id FROM sections WHERE parent_id = ?");
+        $childStmt->execute([$id]);
+        $children = $childStmt->fetchAll(PDO::FETCH_COLUMN);
+        foreach ($children as $child) {
+            $delete_section($db, $child);
+        }
+        $delPosts = $db->prepare("DELETE FROM posts WHERE section_id = ?");
+        $delPosts->execute([$id]);
+        $delSection = $db->prepare("DELETE FROM sections WHERE id = ?");
+        $delSection->execute([$id]);
+    };
+
+    $delete_section($db, $id);
+
+    if ($parent_id) {
+        header('Location: view_section.php?id=' . $parent_id);
+    } else {
+        header('Location: index.php');
+    }
+    exit();
+}
+
+header('Location: index.php');
+exit();
+?>

--- a/edit_post.php
+++ b/edit_post.php
@@ -4,7 +4,7 @@ require_login();
 
 $db = get_db();
 $id = intval($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT title, content FROM posts WHERE id = ?");
+$stmt = $db->prepare("SELECT title, content, section_id FROM posts WHERE id = ?");
 $stmt->execute([$id]);
 $post = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$post) {
@@ -14,6 +14,7 @@ if (!$post) {
 
 $title = $post['title'];
 $content = $post['content'];
+$section_id = (int)$post['section_id'];
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -22,7 +23,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($title && $content) {
         $update = $db->prepare("UPDATE posts SET title = ?, content = ? WHERE id = ?");
         $update->execute([$title, $content, $id]);
-        header('Location: index.php');
+        if ($section_id) {
+            header('Location: view_section.php?id=' . $section_id);
+        } else {
+            header('Location: index.php');
+        }
         exit();
     } else {
         $message = 'Title and content are required';
@@ -48,6 +53,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
 <button type="submit">Update</button>
 </form>
-<p><a href="index.php">Back to posts</a></p>
+<p><a href="<?php echo $section_id ? 'view_section.php?id=' . $section_id : 'index.php'; ?>">Back</a></p>
 </body>
 </html>

--- a/edit_section.php
+++ b/edit_section.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$db = get_db();
+$blog_title = get_blog_title();
+
+$id = intval($_GET['id'] ?? 0);
+$stmt = $db->prepare("SELECT title, parent_id FROM sections WHERE id = ?");
+$stmt->execute([$id]);
+$section = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$section) {
+    header('Location: index.php');
+    exit();
+}
+
+$title = $section['title'];
+$parent_id = (int)$section['parent_id'];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    if ($title) {
+        $update = $db->prepare("UPDATE sections SET title = ? WHERE id = ?");
+        $update->execute([$title, $id]);
+        header('Location: view_section.php?id=' . $id);
+        exit();
+    } else {
+        $message = 'Title is required';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edit Section</title>
+</head>
+<body>
+<h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>
+<h2>Edit Section</h2>
+<?php if ($message): ?><p><?php echo htmlspecialchars($message); ?></p><?php endif; ?>
+<form method="post">
+<label for="title">Title</label><br>
+<input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
+<button type="submit">Update</button>
+</form>
+<p><a href="view_section.php?id=<?php echo $id; ?>">Back</a></p>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -3,7 +3,8 @@ require_once __DIR__ . '/auth.php';
 $db = get_db();
 $blog_title = get_blog_title();
 
-$posts = $db->query("SELECT id, title FROM posts ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+$sections = $db->query("SELECT id, title FROM sections WHERE parent_id IS NULL ORDER BY title")->fetchAll(PDO::FETCH_ASSOC);
+$posts = $db->query("SELECT id, title FROM posts WHERE section_id IS NULL ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
 <html>
@@ -14,11 +15,17 @@ $posts = $db->query("SELECT id, title FROM posts ORDER BY created_at DESC")->fet
 </head>
 <body>
 <h1><?php echo htmlspecialchars($blog_title); ?></h1>
+<h2>Index</h2>
 <?php if (is_logged_in()): ?>
-<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_post.php">New Post</a> | <a href="edit_title.php">Edit Title</a> | <a href="edit_user.php">Edit Account</a> | <a href="logout.php">Logout</a></p>
+<p>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="new_section.php">New Section</a> | <a href="edit_title.php">Edit Title</a> | <a href="edit_user.php">Edit Account</a> | <a href="logout.php">Logout</a></p>
 <?php else: ?>
 <p><a href="login.php">Login</a></p>
 <?php endif; ?>
+<ul>
+<?php foreach ($sections as $section): ?>
+    <li><a href="view_section.php?id=<?php echo $section['id']; ?>"><?php echo htmlspecialchars($section['title']); ?></a><?php if (is_logged_in()): ?> - <a href="edit_section.php?id=<?php echo $section['id']; ?>">Edit</a> | <a href="delete_section.php?id=<?php echo $section['id']; ?>" onclick="return confirm('Delete this section?');">Delete</a><?php endif; ?></li>
+<?php endforeach; ?>
+</ul>
 <ul>
 <?php foreach ($posts as $post): ?>
     <li><a href="view_post.php?id=<?php echo $post['id']; ?>"><?php echo htmlspecialchars($post['title']); ?></a></li>

--- a/new_post.php
+++ b/new_post.php
@@ -5,15 +5,20 @@ require_login();
 $title = '';
 $content = '';
 $message = '';
+$section_id = isset($_GET['section_id']) ? intval($_GET['section_id']) : intval($_POST['section_id'] ?? 0);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $content = trim($_POST['content'] ?? '');
     if ($title && $content) {
         $db = get_db();
-        $stmt = $db->prepare("INSERT INTO posts (title, content) VALUES (?, ?)");
-        $stmt->execute([$title, $content]);
-        header('Location: index.php');
+        $stmt = $db->prepare("INSERT INTO posts (title, content, section_id) VALUES (?, ?, ?)");
+        $stmt->execute([$title, $content, $section_id ?: null]);
+        if ($section_id) {
+            header('Location: view_section.php?id=' . $section_id);
+        } else {
+            header('Location: index.php');
+        }
         exit();
     } else {
         $message = 'Title and content are required';
@@ -37,8 +42,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
 <label for="content">Content</label><br>
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
+<input type="hidden" name="section_id" value="<?php echo htmlspecialchars($section_id); ?>">
 <button type="submit">Publish</button>
 </form>
-<p><a href="index.php">Back to posts</a></p>
+<p><a href="<?php echo $section_id ? 'view_section.php?id=' . $section_id : 'index.php'; ?>">Back</a></p>
 </body>
 </html>

--- a/new_section.php
+++ b/new_section.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/auth.php';
+require_login();
+
+$db = get_db();
+$blog_title = get_blog_title();
+
+$parent_id = isset($_GET['parent_id']) ? intval($_GET['parent_id']) : intval($_POST['parent_id'] ?? 0);
+$title = '';
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    if ($title) {
+        $stmt = $db->prepare("INSERT INTO sections (title, parent_id) VALUES (?, ?)");
+        $stmt->execute([$title, $parent_id ?: null]);
+        if ($parent_id) {
+            header('Location: view_section.php?id=' . $parent_id);
+        } else {
+            header('Location: index.php');
+        }
+        exit();
+    } else {
+        $message = 'Title is required';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>New Section</title>
+</head>
+<body>
+<h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>
+<h2>New Section</h2>
+<?php if ($message): ?><p><?php echo htmlspecialchars($message); ?></p><?php endif; ?>
+<form method="post">
+<label for="title">Title</label><br>
+<input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
+<input type="hidden" name="parent_id" value="<?php echo htmlspecialchars($parent_id); ?>">
+<button type="submit">Create</button>
+</form>
+<p><a href="<?php echo $parent_id ? 'view_section.php?id=' . $parent_id : 'index.php'; ?>">Back</a></p>
+</body>
+</html>

--- a/view_post.php
+++ b/view_post.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/auth.php';
 $db = get_db();
 $blog_title = get_blog_title();
 $id = (int)($_GET['id'] ?? 0);
-$stmt = $db->prepare("SELECT id, title, content, created_at FROM posts WHERE id = ?");
+$stmt = $db->prepare("SELECT id, title, content, created_at, section_id FROM posts WHERE id = ?");
 $stmt->execute([$id]);
 $post = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$post) {
@@ -33,7 +33,11 @@ if (!$post) {
     <?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a> | <a href="delete_post.php?id=<?php echo $post['id']; ?>" onclick="return confirm('Delete this post?');">Delete</a><?php endif; ?>
 </small>
 </article>
+<?php if ($post['section_id']): ?>
+<p><a href="view_section.php?id=<?php echo $post['section_id']; ?>">Back to section</a> | <a href="index.php">Back to index</a></p>
+<?php else: ?>
 <p><a href="index.php">Back to posts</a></p>
+<?php endif; ?>
 <script>
 document.querySelectorAll('time[datetime]').forEach(el => {
     const isoValue = el.getAttribute('datetime');

--- a/view_section.php
+++ b/view_section.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__ . '/auth.php';
+$db = get_db();
+$blog_title = get_blog_title();
+
+$id = intval($_GET['id'] ?? 0);
+$stmt = $db->prepare("SELECT id, title, parent_id FROM sections WHERE id = ?");
+$stmt->execute([$id]);
+$section = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$section) {
+    http_response_code(404);
+    echo "<p>Section not found.</p>\n";
+    exit();
+}
+
+$subStmt = $db->prepare("SELECT id, title FROM sections WHERE parent_id = ? ORDER BY title");
+$subStmt->execute([$id]);
+$subsections = $subStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$postStmt = $db->prepare("SELECT id, title FROM posts WHERE section_id = ? ORDER BY created_at DESC");
+$postStmt->execute([$id]);
+$posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo htmlspecialchars($section['title']); ?> - <?php echo htmlspecialchars($blog_title); ?></title>
+</head>
+<body>
+<h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>
+<h2><?php echo htmlspecialchars($section['title']); ?></h2>
+<?php if (is_logged_in()): ?>
+<p><a href="new_section.php?parent_id=<?php echo $section['id']; ?>">New Subsection</a> | <a href="new_post.php?section_id=<?php echo $section['id']; ?>">New Post</a> | <a href="edit_section.php?id=<?php echo $section['id']; ?>">Edit Section</a> | <a href="delete_section.php?id=<?php echo $section['id']; ?>" onclick="return confirm('Delete this section?');">Delete Section</a></p>
+<?php endif; ?>
+<?php if ($subsections): ?>
+<ul>
+<?php foreach ($subsections as $sub): ?>
+    <li><a href="view_section.php?id=<?php echo $sub['id']; ?>"><?php echo htmlspecialchars($sub['title']); ?></a><?php if (is_logged_in()): ?> - <a href="edit_section.php?id=<?php echo $sub['id']; ?>">Edit</a> | <a href="delete_section.php?id=<?php echo $sub['id']; ?>" onclick="return confirm('Delete this section?');">Delete</a><?php endif; ?></li>
+<?php endforeach; ?>
+</ul>
+<?php endif; ?>
+<ul>
+<?php foreach ($posts as $post): ?>
+    <li><a href="view_post.php?id=<?php echo $post['id']; ?>"><?php echo htmlspecialchars($post['title']); ?></a></li>
+<?php endforeach; ?>
+</ul>
+<?php if ($section['parent_id']): ?>
+<p><a href="view_section.php?id=<?php echo $section['parent_id']; ?>">Back to parent</a> | <a href="index.php">Back to index</a></p>
+<?php else: ?>
+<p><a href="index.php">Back to index</a></p>
+<?php endif; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `sections` table and optional `section_id` on posts
- list sections on index and allow creating, editing and deleting them
- add section pages with support for subsections and posts

## Testing
- `for f in db.php index.php new_post.php edit_post.php delete_post.php view_post.php new_section.php edit_section.php delete_section.php view_section.php; do php -l $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68aa7319d2ac8326b43b5e668b37ec4f