### PR TITLE
Show parent-aware navigation links

### DIFF
--- a/edit_post.php
+++ b/edit_post.php
@@ -15,6 +15,12 @@ if (!$post) {
 $title = $post['title'];
 $content = $post['content'];
 $section_id = (int)$post['section_id'];
+$section = null;
+if ($section_id) {
+    $secStmt = $db->prepare("SELECT title FROM sections WHERE id = ?");
+    $secStmt->execute([$section_id]);
+    $section = $secStmt->fetch(PDO::FETCH_ASSOC);
+}
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -53,6 +59,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
 <button type="submit">Update</button>
 </form>
-<p><a href="<?php echo $section_id ? 'view_section.php?id=' . $section_id : 'index.php'; ?>">Back</a></p>
+<?php if ($section): ?>
+<p><a href="view_section.php?id=<?php echo $section_id; ?>">Back to <?php echo htmlspecialchars($section['title']); ?></a></p>
+<?php else: ?>
+<p><a href="index.php">Back to index</a></p>
+<?php endif; ?>
 </body>
 </html>

--- a/edit_section.php
+++ b/edit_section.php
@@ -46,6 +46,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
 <button type="submit">Update</button>
 </form>
-<p><a href="view_section.php?id=<?php echo $id; ?>">Back</a></p>
+<p><a href="view_section.php?id=<?php echo $id; ?>">Back to <?php echo htmlspecialchars($title); ?></a></p>
 </body>
 </html>

--- a/new_post.php
+++ b/new_post.php
@@ -2,16 +2,23 @@
 require_once __DIR__ . '/auth.php';
 require_login();
 
+$db = get_db();
 $title = '';
 $content = '';
 $message = '';
 $section_id = isset($_GET['section_id']) ? intval($_GET['section_id']) : intval($_POST['section_id'] ?? 0);
 
+$section = null;
+if ($section_id) {
+    $stmt = $db->prepare("SELECT title FROM sections WHERE id = ?");
+    $stmt->execute([$section_id]);
+    $section = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = trim($_POST['title'] ?? '');
     $content = trim($_POST['content'] ?? '');
     if ($title && $content) {
-        $db = get_db();
         $stmt = $db->prepare("INSERT INTO posts (title, content, section_id) VALUES (?, ?, ?)");
         $stmt->execute([$title, $content, $section_id ?: null]);
         if ($section_id) {
@@ -45,6 +52,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="hidden" name="section_id" value="<?php echo htmlspecialchars($section_id); ?>">
 <button type="submit">Publish</button>
 </form>
-<p><a href="<?php echo $section_id ? 'view_section.php?id=' . $section_id : 'index.php'; ?>">Back</a></p>
+<?php if ($section): ?>
+<p><a href="view_section.php?id=<?php echo $section_id; ?>">Back to <?php echo htmlspecialchars($section['title']); ?></a></p>
+<?php else: ?>
+<p><a href="index.php">Back to index</a></p>
+<?php endif; ?>
 </body>
 </html>

--- a/new_section.php
+++ b/new_section.php
@@ -6,6 +6,12 @@ $db = get_db();
 $blog_title = get_blog_title();
 
 $parent_id = isset($_GET['parent_id']) ? intval($_GET['parent_id']) : intval($_POST['parent_id'] ?? 0);
+$parent = null;
+if ($parent_id) {
+    $stmt = $db->prepare("SELECT id, title FROM sections WHERE id = ?");
+    $stmt->execute([$parent_id]);
+    $parent = $stmt->fetch(PDO::FETCH_ASSOC);
+}
 $title = '';
 $message = '';
 
@@ -42,6 +48,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <input type="hidden" name="parent_id" value="<?php echo htmlspecialchars($parent_id); ?>">
 <button type="submit">Create</button>
 </form>
-<p><a href="<?php echo $parent_id ? 'view_section.php?id=' . $parent_id : 'index.php'; ?>">Back</a></p>
+<?php if ($parent): ?>
+<p><a href="view_section.php?id=<?php echo $parent['id']; ?>">Back to <?php echo htmlspecialchars($parent['title']); ?></a></p>
+<?php else: ?>
+<p><a href="index.php">Back to index</a></p>
+<?php endif; ?>
 </body>
 </html>

--- a/view_post.php
+++ b/view_post.php
@@ -11,6 +11,13 @@ if (!$post) {
     echo "<p>Post not found.</p>\n";
     exit();
 }
+
+$section = null;
+if ($post['section_id']) {
+    $secStmt = $db->prepare("SELECT id, title FROM sections WHERE id = ?");
+    $secStmt->execute([$post['section_id']]);
+    $section = $secStmt->fetch(PDO::FETCH_ASSOC);
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -33,8 +40,8 @@ if (!$post) {
     <?php if (is_logged_in()): ?> | <a href="edit_post.php?id=<?php echo $post['id']; ?>">Edit</a> | <a href="delete_post.php?id=<?php echo $post['id']; ?>" onclick="return confirm('Delete this post?');">Delete</a><?php endif; ?>
 </small>
 </article>
-<?php if ($post['section_id']): ?>
-<p><a href="view_section.php?id=<?php echo $post['section_id']; ?>">Back to section</a> | <a href="index.php">Back to index</a></p>
+<?php if ($section): ?>
+<p><a href="view_section.php?id=<?php echo $section['id']; ?>">Back to <?php echo htmlspecialchars($section['title']); ?></a></p>
 <?php else: ?>
 <p><a href="index.php">Back to posts</a></p>
 <?php endif; ?>

--- a/view_section.php
+++ b/view_section.php
@@ -13,6 +13,13 @@ if (!$section) {
     exit();
 }
 
+$parent = null;
+if ($section['parent_id']) {
+    $parentStmt = $db->prepare("SELECT id, title FROM sections WHERE id = ?");
+    $parentStmt->execute([$section['parent_id']]);
+    $parent = $parentStmt->fetch(PDO::FETCH_ASSOC);
+}
+
 $subStmt = $db->prepare("SELECT id, title FROM sections WHERE parent_id = ? ORDER BY title");
 $subStmt->execute([$id]);
 $subsections = $subStmt->fetchAll(PDO::FETCH_ASSOC);
@@ -46,8 +53,8 @@ $posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
     <li><a href="view_post.php?id=<?php echo $post['id']; ?>"><?php echo htmlspecialchars($post['title']); ?></a></li>
 <?php endforeach; ?>
 </ul>
-<?php if ($section['parent_id']): ?>
-<p><a href="view_section.php?id=<?php echo $section['parent_id']; ?>">Back to parent</a> | <a href="index.php">Back to index</a></p>
+<?php if ($parent): ?>
+<p><a href="view_section.php?id=<?php echo $parent['id']; ?>">Back to <?php echo htmlspecialchars($parent['title']); ?></a></p>
 <?php else: ?>
 <p><a href="index.php">Back to index</a></p>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Link back to parent sections/posts using their titles
- Remove direct index links to enforce step-by-step navigation
- Update creation/edit forms to reference parent titles in back links

## Testing
- `php -l edit_post.php`
- `php -l edit_section.php`
- `php -l new_post.php`
- `php -l new_section.php`
- `php -l view_post.php`
- `php -l view_section.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa7760c6908326826c7bf49c190618