### PR TITLE
Allow writing posts in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ This repository contains a simple blogging engine written in PHP with SQLite sto
    - **Username:** `admin`
    - **Password:** `password`
 4. Change the default username and password from the "Edit Account" link.
-5. Create new posts from the "New Post" link.
+5. Create new posts from the "New Post" link. Posts support basic Markdown syntax.
 
 The database file `blog.db` will be created automatically in the project root.

--- a/edit_post.php
+++ b/edit_post.php
@@ -55,7 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <form method="post">
 <label for="title">Title</label><br>
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
-<label for="content">Content</label><br>
+<label for="content">Content (Markdown supported)</label><br>
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
 <button type="submit">Update</button>
 </form>

--- a/markdown.php
+++ b/markdown.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Simple Markdown to HTML converter.
+ * Supports a small subset of Markdown:
+ * - Headings (# through ######)
+ * - Emphasis (*, _, **, __)
+ * - Inline code (`code`)
+ * - Links [text](url)
+ * - Unordered lists starting with - or *
+ * - Paragraphs separated by blank lines
+ *
+ * HTML in the source text is escaped to prevent XSS.
+ */
+function render_markdown(string $text): string {
+    $text = str_replace(["\r\n", "\r"], "\n", $text);
+    $blocks = preg_split('/\n{2,}/', trim($text));
+    $html = '';
+    foreach ($blocks as $block) {
+        if (preg_match('/^#{1,6} /', $block)) {
+            $level = strspn($block, '#');
+            $content = trim(substr($block, $level));
+            $html .= '<h' . $level . '>' . render_markdown_inline($content) . '</h' . $level . ">\n";
+        } elseif (preg_match('/^(?:\-|\*) /m', $block)) {
+            $html .= "<ul>\n";
+            $lines = explode("\n", $block);
+            foreach ($lines as $line) {
+                $item = preg_replace('/^(?:\-|\*)\s+/', '', $line);
+                $html .= '<li>' . render_markdown_inline($item) . "</li>\n";
+            }
+            $html .= "</ul>\n";
+        } else {
+            $html .= '<p>' . render_markdown_inline($block) . "</p>\n";
+        }
+    }
+    return $html;
+}
+
+function render_markdown_inline(string $text): string {
+    $text = htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    // code
+    $text = preg_replace('/`([^`]+)`/', '<code>$1</code>', $text);
+    // strong
+    $text = preg_replace('/\*\*(.+?)\*\*/s', '<strong>$1</strong>', $text);
+    $text = preg_replace('/__(.+?)__/s', '<strong>$1</strong>', $text);
+    // emphasis
+    $text = preg_replace('/\*(.+?)\*/s', '<em>$1</em>', $text);
+    $text = preg_replace('/_(.+?)_/s', '<em>$1</em>', $text);
+    // links
+    $text = preg_replace('/\[([^\]]+)\]\(([^\)]+)\)/', '<a href="$2">$1</a>', $text);
+    return $text;
+}

--- a/new_post.php
+++ b/new_post.php
@@ -47,7 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <form method="post">
 <label for="title">Title</label><br>
 <input type="text" name="title" id="title" value="<?php echo htmlspecialchars($title); ?>"><br>
-<label for="content">Content</label><br>
+<label for="content">Content (Markdown supported)</label><br>
 <textarea name="content" id="content" rows="10" cols="50"><?php echo htmlspecialchars($content); ?></textarea><br>
 <input type="hidden" name="section_id" value="<?php echo htmlspecialchars($section_id); ?>">
 <button type="submit">Publish</button>

--- a/view_post.php
+++ b/view_post.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/markdown.php';
 $db = get_db();
 $blog_title = get_blog_title();
 $id = (int)($_GET['id'] ?? 0);
@@ -30,7 +31,7 @@ if ($post['section_id']) {
 <h1><a href="index.php"><?php echo htmlspecialchars($blog_title); ?></a></h1>
 <article>
 <h2><?php echo htmlspecialchars($post['title']); ?></h2>
-<p><?php echo nl2br(htmlspecialchars($post['content'])); ?></p>
+<?php echo render_markdown($post['content']); ?>
 <?php
     $iso = gmdate('c', strtotime($post['created_at']));
     $display = gmdate('j M Y g:i a', strtotime($post['created_at']));


### PR DESCRIPTION
## Summary
- Add a lightweight Markdown renderer and escape HTML for safety
- Render post bodies through the Markdown parser
- Note Markdown support in post forms and README

## Testing
- `php -l markdown.php view_post.php new_post.php edit_post.php`


------
https://chatgpt.com/codex/tasks/task_e_68aae856b69c832686cd31ca43017a6f