### PR TITLE
Redirect to updated post after editing

### DIFF
--- a/edit_post.php
+++ b/edit_post.php
@@ -29,11 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($title && $content) {
         $update = $db->prepare("UPDATE posts SET title = ?, content = ? WHERE id = ?");
         $update->execute([$title, $content, $id]);
-        if ($section_id) {
-            header('Location: view_section.php?id=' . $section_id);
-        } else {
-            header('Location: index.php');
-        }
+        header('Location: view_post.php?id=' . $id);
         exit();
     } else {
         $message = 'Title and content are required';


### PR DESCRIPTION
## Summary
- Redirect the edit post flow to `view_post.php` after saving so authors immediately see the rendered content.

## Testing
- `php -l edit_post.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaf266a46c8326b649dd9de0530ff8