### PR TITLE
Capitalise Index in navigation links

### DIFF
--- a/edit_post.php
+++ b/edit_post.php
@@ -62,7 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <?php if ($section): ?>
 <p><a href="view_section.php?id=<?php echo $section_id; ?>">Back to <?php echo htmlspecialchars($section['title']); ?></a></p>
 <?php else: ?>
-<p><a href="index.php">Back to index</a></p>
+<p><a href="index.php">Back to Index</a></p>
 <?php endif; ?>
 </body>
 </html>

--- a/new_post.php
+++ b/new_post.php
@@ -55,7 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <?php if ($section): ?>
 <p><a href="view_section.php?id=<?php echo $section_id; ?>">Back to <?php echo htmlspecialchars($section['title']); ?></a></p>
 <?php else: ?>
-<p><a href="index.php">Back to index</a></p>
+<p><a href="index.php">Back to Index</a></p>
 <?php endif; ?>
 </body>
 </html>

--- a/new_section.php
+++ b/new_section.php
@@ -51,7 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <?php if ($parent): ?>
 <p><a href="view_section.php?id=<?php echo $parent['id']; ?>">Back to <?php echo htmlspecialchars($parent['title']); ?></a></p>
 <?php else: ?>
-<p><a href="index.php">Back to index</a></p>
+<p><a href="index.php">Back to Index</a></p>
 <?php endif; ?>
 </body>
 </html>

--- a/view_section.php
+++ b/view_section.php
@@ -56,7 +56,7 @@ $posts = $postStmt->fetchAll(PDO::FETCH_ASSOC);
 <?php if ($parent): ?>
 <p><a href="view_section.php?id=<?php echo $parent['id']; ?>">Back to <?php echo htmlspecialchars($parent['title']); ?></a></p>
 <?php else: ?>
-<p><a href="index.php">Back to index</a></p>
+<p><a href="index.php">Back to Index</a></p>
 <?php endif; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Capitalise 'Index' in back-navigation links across editing, viewing, and new content pages.

## Testing
- `php -l edit_post.php`
- `php -l new_section.php`
- `php -l new_post.php`
- `php -l view_section.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaf34502008326ba19e5560bd61a28